### PR TITLE
Fix: incorrect type in the 'Testing definitions' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { expectType, TypeEqual } from "ts-expect";
 import { add } from "./adder";
 
 expectType<number>(add(1, 2));
-expectType<TypeEqual<boolean, ReturnType<typeof add>>>(true);
+expectType<TypeEqual<number, ReturnType<typeof add>>>(true);;
 expectType<TypeEqual<[number, number], Parameters<typeof add>>>(true);
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { expectType, TypeEqual } from "ts-expect";
 import { add } from "./adder";
 
 expectType<number>(add(1, 2));
-expectType<TypeEqual<number, ReturnType<typeof add>>>(true);;
+expectType<TypeEqual<number, ReturnType<typeof add>>>(true);
 expectType<TypeEqual<[number, number], Parameters<typeof add>>>(true);
 ```
 


### PR DESCRIPTION
The lines in the snippet gave a compiler error: 
```ts
import { expectType, TypeEqual } from "ts-expect";
import { add } from "./adder";

expectType<number>(add(1, 2));
expectType<TypeEqual<boolean, ReturnType<typeof add>>>(true);
expectType<TypeEqual<[number, number], Parameters<typeof add>>>(true);
```

Closes: #28 